### PR TITLE
start.sh: use http 1.0 to avoid keep-alive connections

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -58,7 +58,7 @@ http.server.test(
     ServerClass=SillyServer,
     port='"${PORT:-8000}"',
     bind='0.0.0.0',
-    protocol='HTTP/1.1',
+    protocol='HTTP/1.0',
 )
 "
 


### PR DESCRIPTION
cgi-bin scripts don't handle those well.